### PR TITLE
Adding vulnerable worker category layer

### DIFF
--- a/app/src/components/MainPage.tsx
+++ b/app/src/components/MainPage.tsx
@@ -32,6 +32,7 @@ export type SelectedRoute = {
 export const PROPERTY_LABELS : Record<string, string> = {
   'access_to_hospital': 'Access to Hospital',
   'jobs_cat': 'Access to Jobs',
+  'worker_vulnerability_cat': 'Vulnerable workers',
   'risk_category': 'Flood Risk'
 }
 
@@ -46,7 +47,7 @@ const AVAILABLE_LAYERS: Record<string, Layer> = {
   "2": {
     id: 2,
     layerName: "stop_features",
-    layerURL: "/results/stop_features.geojson",
+    layerURL: "/results/stop_features_v2.geojson",
     isVisible: true,
   },
 };
@@ -63,6 +64,7 @@ export default function MainPage(): JSX.Element {
       "risk_category",
       "access_to_hospital",
       "jobs_cat",
+      "worker_vulnerability_cat",
     ])
   );
   const [selectedProperties, setSelectedProperties] = useState<Array<string>>([
@@ -73,6 +75,7 @@ export default function MainPage(): JSX.Element {
     "risk_category": 0,
     "access_to_hospital": 0,
     "jobs_cat": 0,
+    "worker_vulnerability_cat": 0,
   });
 
   const [selectedRoutes, setSelectedRoutes] = useState<Array<SelectedRoute>>([]);

--- a/app/src/components/Tooltip.tsx
+++ b/app/src/components/Tooltip.tsx
@@ -72,6 +72,13 @@ function Tooltip({ feature, onDismiss }: Props): JSX.Element {
             riskLevel={properties['jobs_cat']}
           />
         </DataRow>
+        <DataRow label={PROPERTY_LABELS['worker_vulnerability_cat']}>
+          <RiskSquares
+            maxRisk={2}
+            color="green"
+            riskLevel={properties['worker_vulnerability_cat']}
+          />
+        </DataRow>
       </dl>
       <button
         onClick={onDismiss}


### PR DESCRIPTION
- Added a column to the data with categories of Social vulnerability of workers in the transit walk-shed. 
- Updated feature file `stop_features_v2.geojson` with this column on S3 bucket
- Modified the MainPage and Tooltip components to include this column as a category for visualization