### PR TITLE
Make route summary sidebar appear on (possibly multiple) route selection from the filter.

### DIFF
--- a/app/src/components/ContextPane.tsx
+++ b/app/src/components/ContextPane.tsx
@@ -15,6 +15,7 @@ type Props = {
   routes: Array<Record<string, RouteRecord>>;
   selectedRoutes: SelectedRoute[];
   setSelectedRoutes: React.Dispatch<React.SetStateAction<Array<SelectedRoute>>>;
+  setDetailedRoutes: React.Dispatch<React.SetStateAction<Array<SelectedRoute>>>;
 };
 
 function ContextPane({
@@ -28,6 +29,7 @@ function ContextPane({
   routes,
   selectedRoutes,
   setSelectedRoutes,
+  setDetailedRoutes,
 }: Props): JSX.Element {
   return (
     <div
@@ -130,7 +132,10 @@ function ContextPane({
         <hr />
         <div className="text-lg flex justify-between">
           <b>Filter by Transit Line</b>
-          <button onClick={() => setSelectedRoutes([])}>Reset</button>
+          <button onClick={() => {
+            setSelectedRoutes([])
+            setDetailedRoutes([])
+          }}>Reset</button>
         </div>
         {selectedRoutes.length > 0 ? (
           <div className="grid grid-cols-4 px-3 gap-1">
@@ -143,6 +148,11 @@ function ContextPane({
                 {route.routeServiced}
               </span>
             ))}
+            <a href='#'
+               className='underline text-blue-600 hover:text-blue-800 py-1 px-2'
+               onClick={() => setDetailedRoutes(selectedRoutes)}>
+              Show summary
+            </a>
           </div>
         ) : null}
         <div className="flex-1 sm:overflow-y-scroll">

--- a/app/src/components/MainPage.tsx
+++ b/app/src/components/MainPage.tsx
@@ -118,17 +118,15 @@ export default function MainPage(): JSX.Element {
   const [selectedRoutes, setSelectedRoutes] = useState<Array<SelectedRoute>>(
     [],
   );
-  const [detailedRoutes, setDetailedRoutes] = useState<SelectedRoute>({
-    city: '',
-    routeType: '',
-    routeServiced: '',
-  });
+  const [detailedRoutes, setDetailedRoutes] = useState<Array<SelectedRoute>>(
+    [],
+  );
 
   const [layers, setLayers] = useState(AVAILABLE_LAYERS);
   let remoteLayers = useRemoteLayers(layers);
   // console.log(remoteLayers)
   let routeSummary = useRouteSummary(remoteLayers, detailedRoutes);
-  // console.log(routeSummary)
+  // console.log(routeSummary);
   // let remoteLayerPropertyValues = useRemoteLayerPropertyValues(remoteLayers, selectedProperties);
 
   let sourceLayerConfigs = useSourceLayerConfigs(
@@ -216,14 +214,13 @@ export default function MainPage(): JSX.Element {
         routes={AVAILABLE_ROUTES}
         selectedRoutes={selectedRoutes}
         setSelectedRoutes={setSelectedRoutes}
+        setDetailedRoutes={setDetailedRoutes}
       />
-      {detailedRoutes.city != '' && (
-        <RouteSummaryPane
-          routeSummary={routeSummary}
-          detailedRoutes={detailedRoutes}
-          setDetailedRoutes={setDetailedRoutes}
-        />
-      )}
+      <RouteSummaryPane
+        routeSummary={routeSummary}
+        detailedRoutes={detailedRoutes}
+        setDetailedRoutes={setDetailedRoutes}
+      />
       <MapComponent
         center={selectedRegion}
         layers={layers}

--- a/app/src/components/MapComponent.tsx
+++ b/app/src/components/MapComponent.tsx
@@ -13,7 +13,7 @@ type MapProps = {
   remoteLayers: Array<RemoteLayer>;
   sourceLayerConfigs: Record<string, any>;
   center: [number, number];
-  setDetailedRoutes: React.Dispatch<React.SetStateAction<SelectedRoute>>;
+  setDetailedRoutes: React.Dispatch<React.SetStateAction<Array<SelectedRoute>>>;
 };
 
 function MapComponent({

--- a/app/src/components/RouteSidebar.tsx
+++ b/app/src/components/RouteSidebar.tsx
@@ -17,30 +17,36 @@ function LineLabel(props: {
 type RouteProps = {
     routeSummary: Array<RouteSummary>;
     // routes: Array<Record<string, RouteRecord>>;
-    detailedRoutes: SelectedRoute;
-    setDetailedRoutes: React.Dispatch<React.SetStateAction<SelectedRoute>>;
+    detailedRoutes: Array<SelectedRoute>;
+    setDetailedRoutes: React.Dispatch<React.SetStateAction<Array<SelectedRoute>>>;
   };
 
 function RouteSummaryPane({
     routeSummary,
     detailedRoutes,
     setDetailedRoutes,
-  }: RouteProps): JSX.Element {  
+  }: RouteProps): JSX.Element {
+
+    if (detailedRoutes.length === 0) {
+        return <></>
+    }
+
+    const combinedRouteName = detailedRoutes.flatMap(r => r.routeServiced).join(", ");
+
     return (
         <div
             id="SummaryPane"
             className="bg-white min-w-fit h-full shadow flex flex-col"
         >
-            {/* min-w-max max-w-sm */}
-            
+           
             <div className="p-2 border-b border-b-slate-400">
                 <FontAwesomeIcon 
                     icon={IconType.faArrowLeft} 
-                    onClick={()=>{setDetailedRoutes({city:'',routeType:'',routeServiced:''})}}
+                    onClick={()=>{setDetailedRoutes([])}}
                     className="text-base font-xl hover:bg-slate-200 cursor-pointer transition-colors pt-3"/>
-                <b className="pl-4 pt-2">{detailedRoutes.routeServiced}</b>
+                <b className="pl-4 pt-2">{combinedRouteName}</b>
                 <div className="flex flex-col pl-7 space-y-2">
-                    {detailedRoutes.routeType} Route
+                    {(detailedRoutes.length === 1) ? detailedRoutes[0].routeType + " Route": "Multiple Routes"}
                 </div>
             </div>
             
@@ -48,16 +54,16 @@ function RouteSummaryPane({
             <div className="flex flex-col pt-4 pl-4 space-y-2"><b>Total Stops</b></div>
 
             <div className="flex flex-col pt-2 pl-4 space-y-2">
-                <b className="text-xl">{JSON.stringify(routeSummary.filter(function(e:any) {return e.route == detailedRoutes.routeServiced})[0]['count'])}</b>
+                <b className="text-xl">{JSON.stringify(routeSummary.filter(function(e:any) {return e.route == combinedRouteName})[0]['count'])}</b>
             </div>
 
-            <BarChart label='Flood Risk' data={routeSummary.filter(function(e:any) {return e.route == detailedRoutes.routeServiced})[0]['flood_risk']}></BarChart>
+            <BarChart label='Flood Risk' data={routeSummary.filter(function(e:any) {return e.route == combinedRouteName})[0]['flood_risk']}></BarChart>
 
-            <BarChart label='Access to Hospitals' data={routeSummary.filter(function(e:any) {return e.route == detailedRoutes.routeServiced})[0]['hospital_access']}></BarChart>
+            <BarChart label='Access to Hospitals' data={routeSummary.filter(function(e:any) {return e.route == combinedRouteName})[0]['hospital_access']}></BarChart>
             
-            <BarChart label='Access to Jobs' data={routeSummary.filter(function(e:any) {return e.route == detailedRoutes.routeServiced})[0]['job_access']}></BarChart>
+            <BarChart label='Access to Jobs' data={routeSummary.filter(function(e:any) {return e.route == combinedRouteName})[0]['job_access']}></BarChart>
 
-            <BarChart label='Vulnerable workers' data={routeSummary.filter(function(e:any) {return e.route == detailedRoutes.routeServiced})[0]['worker_vulnerability']}></BarChart>
+            <BarChart label='Vulnerable workers' data={routeSummary.filter(function(e:any) {return e.route == combinedRouteName})[0]['worker_vulnerability']}></BarChart>
 
             
         </div>

--- a/app/src/components/Tooltip.tsx
+++ b/app/src/components/Tooltip.tsx
@@ -24,7 +24,7 @@ function DataRowLink(props: {
   route_type:string;
   routes_serviced:string;
   label: string;
-  setDetailedRoutes: React.Dispatch<React.SetStateAction<SelectedRoute>>;
+  setDetailedRoutes: React.Dispatch<React.SetStateAction<Array<SelectedRoute>>>;
 }): JSX.Element {
   const { city, route_type, routes_serviced, label, setDetailedRoutes } = props;
   let routes = JSON.parse(routes_serviced)
@@ -33,9 +33,8 @@ function DataRowLink(props: {
   return (
     <div className="w-full flex text-sm">
       <dt className="flex-1 pr-2">{label}</dt>
-      {routes.map((r:string, i:number) => (<dd className="flex underline text-blue-600 hover:text-blue-800 visited:text-purple-600 text-xs" key={i} onClick={()=>setDetailedRoutes({city:city,routeType:route_type,routeServiced:r})}>{i< r_len-1 ? r+',' : r}</dd>)
+      {routes.map((r:string, i:number) => (<dd className="flex underline text-blue-600 hover:text-blue-800 visited:text-purple-600 text-xs" key={i} onClick={()=>setDetailedRoutes([{city:city,routeType:route_type,routeServiced:r}])}>{i< r_len-1 ? r+',' : r}</dd>)
       )}
-      
     </div>
   );
 }
@@ -59,7 +58,7 @@ function RiskSquares(props: {
 type Props = {
   feature: MapboxGeoJSONFeature;
   onDismiss: () => void;
-  setDetailedRoutes: React.Dispatch<React.SetStateAction<SelectedRoute>>;
+  setDetailedRoutes: React.Dispatch<React.SetStateAction<Array<SelectedRoute>>>;
 };
 
 function Tooltip({ feature, onDismiss, setDetailedRoutes }: Props): JSX.Element {


### PR DESCRIPTION
Currently the route summary sidebar appears from clicking on a route in the tooltip only. This commit -
1. Makes it possible to view summary based on route selection from the filter as well.
2. Makes it possible to view combined summary for multiple route selections in the filter.
3. Ensures that a stop serving more than one route doesn't get counted twice in combined summary.

Fixes issue #21 

Screenshot - 

![Screenshot from 2023-04-25 12-50-21](https://user-images.githubusercontent.com/12870972/234347497-b67364bd-2443-45a6-a22f-d26fd613e6e2.png)
