### PR TITLE
Hide filter toggles irrelevant to the selected city

### DIFF
--- a/app/src/components/ContextPane.tsx
+++ b/app/src/components/ContextPane.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import Dropdown from './ui/Dropdown';
 import { RouteRecord } from '../utils/availableRoutes';
+import { Cities } from '../lib/cities';
 
 type Props = {
   availableProperties: Set<string>;
@@ -10,8 +11,9 @@ type Props = {
   selectedProperties: Array<string>;
   layers: Record<string, Layer>;
   updateLayer: (layer: Layer) => void;
-  regions: Record<string, [number, number]>;
-  setSelectedRegion: React.Dispatch<React.SetStateAction<[number, number]>>;
+  regions: Record<Cities, [number, number]>;
+  selectedCity: Cities;
+  setSelectedCity: React.Dispatch<React.SetStateAction<Cities>>;
   routes: Array<Record<string, RouteRecord>>;
   selectedRoutes: SelectedRoute[];
   setSelectedRoutes: React.Dispatch<React.SetStateAction<Array<SelectedRoute>>>;
@@ -24,7 +26,8 @@ function ContextPane({
   selectedProperties,
   setSelectedProperties,
   regions,
-  setSelectedRegion,
+  selectedCity,
+  setSelectedCity,
   routes,
   selectedRoutes,
   setSelectedRoutes,
@@ -37,7 +40,7 @@ function ContextPane({
       <div className="p-5 border-b border-b-slate-400">
         <select
           onChange={e => {
-            setSelectedRegion(regions[e.target.value]);
+            setSelectedCity(e.target.value as Cities);
           }}
           className="text-2xl"
         >
@@ -52,7 +55,7 @@ function ContextPane({
       <div className="px-4 space-y-4 pt-4 flex flex-col h-full sm:overflow-y-hidden">
         <div className="border-b border-b-slate-300 pb-4">
           {Object.values(layers)
-            .filter(layer => !layer.hideToggle)
+            .filter(layer => !layer.hideToggle && (layer.city === undefined || layer.city === selectedCity))
             .map(layer => {
               return (
                 <div className="space-x-2">
@@ -149,7 +152,7 @@ function ContextPane({
           <ul>
             {routes.map(availableRoute =>
               Object.values(availableRoute).map(routeRecord => {
-                return (
+                return ((routeRecord.city === selectedCity) ? (
                   <details key={routeRecord.city} className="pb-2">
                     <summary className="pb-1">{routeRecord.display_name} lines</summary>
                     {routeRecord.route_types.map((type, index) => {
@@ -199,7 +202,7 @@ function ContextPane({
                         </details>
                       );
                     })}
-                  </details>
+                  </details>): <></>
                 );
               }),
             )}

--- a/app/src/components/ContextPane.tsx
+++ b/app/src/components/ContextPane.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import Dropdown from './ui/Dropdown';
 import { RouteRecord } from '../utils/availableRoutes';
-import { Cities } from '../lib/cities';
+import { Cities } from '../libs/cities';
 
 type Props = {
   availableProperties: Set<string>;

--- a/app/src/components/MainPage.tsx
+++ b/app/src/components/MainPage.tsx
@@ -11,7 +11,7 @@ import { useSourceLayerConfigs } from '../utils/sourceLayerConfigs';
 import { AVAILABLE_ROUTES } from '../utils/availableRoutes';
 import { RouteSummary, useRouteSummary } from '../hooks/useRouteSummary';
 import * as Fathom from "fathom-client";
-import { Cities } from '../lib/cities';
+import { Cities } from '../libs/cities';
 
 export type Layer = {
   id: number;

--- a/app/src/components/MainPage.tsx
+++ b/app/src/components/MainPage.tsx
@@ -11,6 +11,7 @@ import { useSourceLayerConfigs } from '../utils/sourceLayerConfigs';
 import { AVAILABLE_ROUTES } from '../utils/availableRoutes';
 import { RouteSummary, useRouteSummary } from '../hooks/useRouteSummary';
 import * as Fathom from "fathom-client";
+import { Cities } from '../lib/cities';
 
 export type Layer = {
   id: number;
@@ -19,6 +20,7 @@ export type Layer = {
   layerURL: string;
   isVisible: boolean;
   hideToggle: boolean;
+  city?: Cities;
 };
 
 export type RemoteLayer = {
@@ -76,6 +78,7 @@ const AVAILABLE_LAYERS: Record<string, Layer> = {
     isVisible: false,
     sourceLayer: 'hr_2050_flood_zones',
     hideToggle: false,
+    city: Cities.HamptonRoads,
   },
   '5': {
     id: 5,
@@ -84,18 +87,17 @@ const AVAILABLE_LAYERS: Record<string, Layer> = {
     isVisible: false,
     sourceLayer: 'nyc_2050_flooding',
     hideToggle: false,
+    city: Cities.NewYorkCity,
   },
 };
 
-const AVAILABLE_REGIONS: Record<string, [number, number]> = {
-  'New York City': [-73.95, 40.72],
-  'Hampton Roads': [-76.39, 36.96],
+const AVAILABLE_REGIONS: Record<Cities, [number, number]> = {
+  [Cities.NewYorkCity]: [-73.95, 40.72],
+  [Cities.HamptonRoads]: [-76.39, 36.96],
 };
 
 export default function MainPage(): JSX.Element {
-  const [selectedRegion, setSelectedRegion] = useState<[number, number]>(
-    AVAILABLE_REGIONS['New York City'],
-  );
+  const [selectedCity, setSelectedCity] = useState<Cities>(Cities.NewYorkCity);
   const [availableProperties, setAvailableProperties] = useState<Set<string>>(
     new Set([
       'flood_risk_category',
@@ -207,7 +209,8 @@ export default function MainPage(): JSX.Element {
       />
       <ContextPane
         regions={AVAILABLE_REGIONS}
-        setSelectedRegion={setSelectedRegion}
+        selectedCity={selectedCity}
+        setSelectedCity={setSelectedCity}
         layers={layers}
         updateLayer={updateLayer}
         availableProperties={availableProperties}
@@ -225,7 +228,7 @@ export default function MainPage(): JSX.Element {
         />
       )}
       <MapComponent
-        center={selectedRegion}
+        center={AVAILABLE_REGIONS[selectedCity]}
         layers={layers}
         remoteLayers={remoteLayers}
         sourceLayerConfigs={sourceLayerConfigs}

--- a/app/src/libs/cities.ts
+++ b/app/src/libs/cities.ts
@@ -1,0 +1,4 @@
+export enum Cities {
+  NewYorkCity = 'New York City',
+  HamptonRoads = 'Hampton Roads'
+};

--- a/app/src/utils/availableRoutes.ts
+++ b/app/src/utils/availableRoutes.ts
@@ -1,4 +1,4 @@
-import { Cities } from "../lib/cities";
+import { Cities } from "../libs/cities";
 
 export type RouteRecord = {
   city: Cities;

--- a/app/src/utils/availableRoutes.ts
+++ b/app/src/utils/availableRoutes.ts
@@ -1,5 +1,7 @@
+import { Cities } from "../lib/cities";
+
 export type RouteRecord = {
-  city: string;
+  city: Cities;
   display_name: string;
   route_types: Array<{
     route_type: string;
@@ -10,7 +12,7 @@ export type RouteRecord = {
 export const AVAILABLE_ROUTES : Array<Record<string, RouteRecord>> = [
     {
       "Hampton Roads": { 
-        "city": "hr",
+        "city": Cities.HamptonRoads,
         "display_name": "Hampton Roads",
         "route_types": [
           {
@@ -111,7 +113,7 @@ export const AVAILABLE_ROUTES : Array<Record<string, RouteRecord>> = [
     },
     {
       "NYC": {
-        "city": "nyc",
+        "city": Cities.NewYorkCity,
         "display_name": "New York City",
         "route_types": [
           {


### PR DESCRIPTION
This commit -
1. Hides the layers that are irrelevant for the selected city. Previously all layers for all cities were being shown.
2. Hides the transit lines that are irrelevant for the selected city. Previously all transit lines for all cities were being shown.
3. Introduces Cities enum for type-safe way of specifying city anywhere in the code. Previously strings were being used which can easily lead to errors.
4. Replaces the use of string with Cities enum for Available Routes and Available Regions records.

This commit fixes the issue mentioned at #40 

Here are the screenshots showing the desired UI change -

![image](https://user-images.githubusercontent.com/12870972/235810967-588f2303-35bd-4b85-a686-bfd7b276a94f.png)
![image](https://user-images.githubusercontent.com/12870972/235811033-27890d61-3253-41f3-ba9e-caed664527a2.png)
